### PR TITLE
Bugfix intrument note length

### DIFF
--- a/src/yass/YassPlayer.java
+++ b/src/yass/YassPlayer.java
@@ -1139,7 +1139,7 @@ public class YassPlayer {
                         }
 
                         if (midiEnabled) {
-                            midi.playNote(midiPitch, outMillis - inMillis);
+                            midi.playNote(midiPitch, (nextClickEnd - nextClick) / 1000);
                         }
 
                         if (++clicksPos < n) {


### PR DESCRIPTION
I found a bug when calculating the midi note length in YassPlayer which makes the end note threads in YassMIDI live for way longer than they should and makes the tones ring out for waaaaay longer than they should.

In it's current codition, it plays the correct note length if you play a single note, but when playing a line or the whole song, every note is basically the length of the rest of the song
